### PR TITLE
Follow source symlink

### DIFF
--- a/include/python/link_project.py
+++ b/include/python/link_project.py
@@ -21,7 +21,10 @@ def link(source, dest, verbase=False):
         raise LinkProjectError("%s not exist." % source)
 
     print("Link %s -> %s" % (source, dest))
-    subprocess.check_call(['cp', '-al', source, dest])
+    if os.path.islink(source):
+        subprocess.check_call(['cp', '-aH', source, dest])
+    else:
+        subprocess.check_call(['cp', '-al', source, dest])
 
 
 def link_scripts(chroot):


### PR DESCRIPTION
Hello,

This PR solves an issue when `source/myproject` is a symbolic link.
Symbolic link itself is copied instead of the content it points to.

With this PR, if `myproject` is a symbolic link, `link_project.py` follows it and copies its content to the chroot destination.
It copies instead of hard-linking, because files could easily be on another FS.

Thank you 👍 

Ben