### PR TITLE
include/toolkit.config: add support for DSM 6.2

### DIFF
--- a/include/toolkit.config
+++ b/include/toolkit.config
@@ -2,3 +2,4 @@
 
 AvailablePlatform_6_0="6281 alpine alpine4k armada370 armada375 armada38x armadaxp avoton braswell bromolow cedarview comcerto2k evansport monaco qoriq x64 broadwell grantley"
 AvailablePlatform_6_1="6281 alpine alpine4k armada370 armada375 armada38x armadaxp avoton braswell broadwell bromolow cedarview comcerto2k dockerx64 evansport grantley hi3535 kvmx64 monaco qoriq x64 rtd1296 denverton apollolake"
+AvailablePlatform_6_2="6281 alpine alpine4k armada370 armada375 armada38x armadaxp avoton braswell broadwell bromolow cedarview comcerto2k dockerx64 evansport grantley kvmx64 monaco qoriq x64 rtd1296 apollolake"


### PR DESCRIPTION
This changes seems to get me passed issue #9 . EnvDeplay runs, and I can build my project for DSM 6.2. However, I do not know if that is enough to properly support all of the DSM 6.2 platform.

Fixes #9 
