### PR TITLE
Update exec_env.py to mount /dev/null and /dev/urandom

### DIFF
--- a/include/python/exec_env.py
+++ b/include/python/exec_env.py
@@ -63,9 +63,13 @@ class ExecuteEnv(object):
 
 class ChrootEnv(ExecuteEnv):
     def execute(self, cmd, display=False, logfile="", **kwargs):
-        mount_point = os.path.join(self.chroot_dir, 'proc')
-        if not os.path.ismount(mount_point):
-            subprocess.check_call(['mount', '-t', 'proc', 'none', mount_point])
+        proc_mount_point = os.path.join(self.chroot_dir, 'proc')
+        if not os.path.ismount(proc_mount_point):
+            subprocess.check_call(['mount', '-t', 'proc', 'none', proc_mount_point])
+
+        dev_mount_point = os.path.join(self.chroot_dir, 'dev')
+        if not os.path.ismount(dev_mount_point):
+            subprocess.check_call(['mount', '--bind', '/dev', dev_mount_point])
 
         if isinstance(cmd, list):
             cmd = ['chroot', self.chroot_dir] + cmd


### PR DESCRIPTION
Without this change, builds fail due to invalid reference/permissions for /dev/null and /dev/urandom. This change mounts those in the environment to eliminate those errors.

Fix https://github.com/SynologyOpenSource/pkgscripts-ng/issues/48

Note this is targeting DSM7.0 but a port is likely is needed in other branches too. 